### PR TITLE
Use body as page container

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -25,7 +25,8 @@ html {
 
 body {
   box-sizing: border-box;
-  margin: 0;
+  margin: 0 auto;
+  max-width: 60em;
 }
 
 img {


### PR DESCRIPTION
- centers the pages
- applies `max-width` to `60em` which computes to `960px` in standard use