### PR TITLE
Remove iframe border via CSS

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -36,6 +36,7 @@ img {
 }
 
 iframe {
+  border-style: none;
   box-sizing: border-box;
   max-width: 100%;
 }


### PR DESCRIPTION
Using CSS because `frameborder` is obsolete