### PR TITLE
Allow menu to wrap

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,7 @@
   </a>
 </header>
 
-<nav class="block-table m0 mb4">
+<nav class="m0 mb4">
   <a class="mr2 mb2" href={{ "/bio/" | relative_url }}>Bio</a>
   <a class="mr2 mb2" href="http://aaronirwin.bandcamp.com">Store</a>
   <a class="mr2 mb2" href={{ "/albums/" | relative_url }}>Albums</a>


### PR DESCRIPTION
`display: table` was preventing wrapping in slim viewports