### PR TITLE
Remove implicit banner role

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <link rel="stylesheet" href={{ "/css/theme.css" | relative_url }}>
 
-<header class="m0 mb4 block-table" role="banner">
+<header class="m0 mb4 block-table">
   <a class="block-flow decor-none color-same" href={{ "/" | relative_url }} rel="home" accesskey="1">
     <h1 class="font-xxl font-700 m0">Aaron Irwin</h1>
     <span class="font-m font-600">Saxophonist &amp; Composer</span>


### PR DESCRIPTION
Per https://html5.validator.nu

> **Warning:** The banner role is unnecessary for element `header`