### PR TITLE
Convert albums markdown ul to HTML ol

### DIFF
--- a/albums.md
+++ b/albums.md
@@ -5,7 +5,9 @@ permalink: /albums/index.html
 
 # Albums
 
+<ol class="pad-0">
 {% assign albums = (site.albums | sort: "chronology") | reverse %}
 {% for item in albums %}
-  - [![{{ item.title }}]({{ item.cover.min }})]({{ item.url | relative_url }})
+  <li class="block-flow">[![{{ item.title }}]({{ item.cover.min }})]({{ item.url | relative_url }})
 {% endfor %}
+</ol>


### PR DESCRIPTION
- HTML because it needs classes for styling
- `ol` makes sense semantically because the list is ordered
