### PR TITLE
Quote href to render anchor

### DIFF
--- a/albums.md
+++ b/albums.md
@@ -9,7 +9,7 @@ permalink: /albums/index.html
 {% assign albums = (site.albums | sort: "chronology") | reverse %}
 {% for item in albums %}
   <li class="block-flow">
-    <a href={{ item.url | relative_url }}>
+    <a href="{{ item.url | relative_url }}">
       <img
         alt="{{ item.title }}"
         width="480"


### PR DESCRIPTION
#35 rendered with the anchor angle brackets escaped like 

```
&lt;a href=/aaronirwin.com/albums/wobegon/&gt;
```
instead of HTML as intended