### PR TITLE
redirect news url

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 title: Aaron Irwin: saxophonist and composer
-redirect_from: /news/
 ---
 
 <a href={{ "/albums/music-for-sextet/" | relative_url }}>

--- a/news.html
+++ b/news.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>redirect</title>
+<meta http-equiv=refresh content="0; url=/">


### PR DESCRIPTION
manually redirect [news](https://aaronirwin.com/news) to the [homepage](https://aaronirwin.com) via meta redirect because the `redirect_from` plugin isn't working