### PR TITLE
omg object-fit cover responsive

### DIFF
--- a/albums.md
+++ b/albums.md
@@ -11,11 +11,11 @@ permalink: /albums/index.html
 {% assign albums = (site.albums | sort: "chronology") | reverse %}
 {% for item in albums %}
   <li class="block-flow m0">
-    <a class="block-flex flex-column" href="{{ item.url | relative_url }}">
+    <a class="block-flex flex-column square" href="{{ item.url | relative_url }}">
       <img
+        class="omg"
         alt="{{ item.title }}"
         width="480"
-        height="480"
         src="{{ item.cover.min }}" />
     </a>
   </li>

--- a/css/theme.css
+++ b/css/theme.css
@@ -48,16 +48,22 @@ body {
   padding: 1em;
 }
 
+.square {
+  position: relative;
+  padding: 100% 0 0 0;
+}
+
+.omg {
+  object-fit: cover;
+  position: absolute;
+  height: 100%;
+  top: 0;
+}
+
 img {
   box-sizing: border-box;
   max-width: 100%;
   height: auto;
-}
-
-iframe {
-  border-style: none;
-  box-sizing: border-box;
-  max-width: 100%;
 }
 
 figure {


### PR DESCRIPTION
### ensure [albums](https://aaronirwin.com/albums) appear square and responsive


```css
.square {
  position: relative;
  padding: 100% 0 0 0;
}

.omg {
  object-fit: cover;
  position: absolute;
  height: 100%;
  top: 0;
}

img {
  box-sizing: border-box;
  max-width: 100%;
  height: auto;
}
```