### PR TITLE
max-height

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -57,7 +57,7 @@ body {
 .omg {
   object-fit: cover;
   position: absolute;
-  height: 100%;
+  max-height: 100%;
   top: 0;
 }
 


### PR DESCRIPTION
`height` was causing tall images in wide viewports while `max-height` does #132 desires